### PR TITLE
centralized cache for CI workflow on the main branch

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -10,7 +10,7 @@ name: R
 
 on:
   push:
-    branches: [ "CI-for-R-with-github-workflow" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
I noticed that the CI check for the most recent two pull requests took very long and the cache mechanism did not seem to work. It turns out caches of workflows for different pull requests do not share. There needs to be a centralized cache on the default main branch to be shared across pull requests and child branches. This update is meant to add this. There should be a cache to be shared by all pull requests after a first workflow run is triggered by push to main and done on main.

<img width="737" alt="image" src="https://github.com/wenyunie/speed_dating_analysis/assets/143786716/953616b8-ba05-40ca-83a4-e028ced78726">

